### PR TITLE
machine translation eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ matrices with word2vec embeddings. You can download those embeddings
 recommended to use the option `--word2vec_binary XXX` where XXX is the
 path to the extracted/downloaded word embeddings.
 
+*A note about evaluating with MT metrics:* the machine translation
+metrics, with the exception of sacrebleu, are based on
+[pycocoevalcap](https://github.com/salaniz/pycocoevalcap) which itself
+has several dependencies. In particular, it requires java 1.8+, and
+for the permissions setting to be set so that temporary files can be
+written wherever pip installs pycocoevalcap. If you don't have these
+additional, only BLEU will be computed, and a warning will print.
+
 ## How to run
 
 ### Preparing the dataset

--- a/eval_utils.py
+++ b/eval_utils.py
@@ -111,14 +111,17 @@ def compute_match_metrics_doc(docs,
                     for inner_idx in range(len(all_refs))]
         all_refs_final.append(cur_refs)
     
-    all_mt_metrics = compute_mt_metrics(all_sys, all_refs_final)
+    all_mt_metrics = compute_mt_metrics(all_sys, all_refs_final, args)
     return all_aucs, all_match_metrics, all_mt_metrics
 
 
-def compute_mt_metrics(all_sys, all_refs):
+def compute_mt_metrics(all_sys, all_refs, args):
     res_dict = {}
     sacre_bleu = sacrebleu.corpus_bleu(all_sys, all_refs)
     res_dict['sacre_bleu'] = sacre_bleu.score
+
+    if not args.compute_mscoco_eval_metrics:
+        return res_dict
     
     try:
         tokenizer = PTBTokenizer()

--- a/eval_utils.py
+++ b/eval_utils.py
@@ -78,10 +78,12 @@ def compute_match_metrics_doc(docs,
             true_adj[text_idx, t[1]] = 1
         for image_idx, t in enumerate(images):
             if t[1] == -1: continue
-            im2predicted_captions[image_idx] = im2all_predicted_captions[image_idx]
-            im2ground_truth_captions[image_idx].append(text[t[1]][0])
             true_adj[t[1], image_idx] = 1
 
+        for text_gt_idx, image_gt_idx in zip(*np.where(true_adj==1)):
+            im2predicted_captions[image_gt_idx] = im2all_predicted_captions[image_idx]
+            im2ground_truth_captions[image_gt_idx].append(text[text_gt_idx][0])
+            
         for img_idx, pred in im2predicted_captions.items():
             all_refs.append(im2ground_truth_captions[img_idx])
             all_sys.append(pred)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,6 @@ tqdm
 spacy
 gensim
 nltk
+sacrebleu
 tensorflow>=2.1
+git+https://github.com/jmhessel/pycocoevalcap

--- a/train_doc.py
+++ b/train_doc.py
@@ -182,6 +182,10 @@ def parse_args():
                         default='hinge',
                         choices=['hinge', 'logistic'],
                         type=str)
+    parser.add_argument('--compute_mscoco_eval_metrics',
+                        help='Should we compute the mscoco MT metrics?',
+                        default=0,
+                        type=int)
     args = parser.parse_args()
 
     # check to make sure that various flags are set correctly

--- a/train_doc.py
+++ b/train_doc.py
@@ -524,7 +524,7 @@ def main():
         single_image_doc_model = tf.keras.models.load_model(best_image_model_str)
 
         if ground_truth:
-            val_aucs, val_match_metrics = eval_utils.compute_match_metrics_doc(
+            val_aucs, val_match_metrics, val_mt_metrics = eval_utils.compute_match_metrics_doc(
                 val,
                 image_features,
                 image_idx2row,
@@ -533,7 +533,7 @@ def main():
                 single_img_doc_model,
                 args)
 
-            test_aucs, test_match_metrics = eval_utils.compute_match_metrics_doc(
+            test_aucs, test_match_metrics, test_mt_metrics = eval_utils.compute_match_metrics_doc(
                 test,
                 image_features,
                 image_idx2row,
@@ -544,14 +544,18 @@ def main():
         else:
             val_aucs, test_aucs = None, None
             val_match_metrics, test_match_metrics = None, None
+            val_mt_metrics, test_mt_metrics = None, None
 
+            
         output = {'logs':best_logs,
                   'best_sentence_model_str':best_sentence_model_str,
                   'best_image_model_str':best_image_model_str,
                   'val_aucs':val_aucs,
                   'val_match_metrics':val_match_metrics,
+                  'val_mt_metrics':val_mt_metrics,
                   'test_aucs':test_aucs,
                   'test_match_metrics':test_match_metrics,
+                  'test_mt_metrics':test_mt_metrics,
                   'args':args,
                   'epoch':best_epoch}
 


### PR DESCRIPTION
Add support for machine translation metrics. These metrics are computed as follows: for a fixed image, if that image has at least one ground truth sentence, retrieve the most likely sentence in the document, and compare it to the ground truth(s) at a corpus level. This will bias towards longer documents, i.e., more (pred, [ground truth]) pairs can be generated for docs with more image links.